### PR TITLE
change busybox to curl-image

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
     email: github@une-pause-cafe.fr
     url: https://une-tasse-de.cafe
 name: common
-version: v0.4.4
+version: v0.4.5
 appVersion: "0"
 kubeVersion: ">= 1.18"
 home: https://github.com/RubxKube/common-charts

--- a/charts/common/templates/tests/test-connection.yaml
+++ b/charts/common/templates/tests/test-connection.yaml
@@ -9,9 +9,9 @@ metadata:
     "helm.sh/hook": test
 spec:
   containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
+    - name: curl
+      image: curlimages/curl
+      command: ['curl', '-v']
       args: ['{{ .Values.name }}:{{ .Values.service.servicePort }}']
   restartPolicy: Never
 {{ end }}
@@ -29,7 +29,7 @@ spec:
   containers:
     - name: curl
       image: curlimages/curl:7.70.0 
-      command: ['curl']
+      command: ['curl', '-v']
       args: ['{{ .Values.name }}:{{ .Values.service.servicePort }}{{ .Values.tests.curlHostHeader.path }}', '-H', '"Host:{{ .Values.ingress.hostName }}:{{ .Values.service.servicePort }}"']
   restartPolicy: Never
 {{ end }}


### PR DESCRIPTION
I'm having problems with the wget preinstalled on busyboxes, which causes chart tests to fail. This PR allows you to switch to 100% curl. 
